### PR TITLE
Handling models

### DIFF
--- a/src/featuresx.h
+++ b/src/featuresx.h
@@ -24,7 +24,9 @@ using theia::Keypoint;
 
 class Features {
  public:
-  typedef std::pair<std::vector<theia::Keypoint>, std::vector<Eigen::VectorXf> > FeatureVectors;
+  typedef std::pair<
+      std::vector<theia::Keypoint>, std::vector<Eigen::VectorXf>
+  > FeatureVectors;
   typedef std::unordered_map<std::string, FeatureVectors> FeaturesMap;
 
   Features(Storage* storage, Options* options);

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -3,6 +3,7 @@
 #include "report.h"
 
 #include <QDateTime>
+#include <QDir>
 #include <QFile>
 #include <QProcessEnvironment>
 #include <QTextStream>
@@ -23,6 +24,13 @@ Report::Report(Project* project) : project_(project) {
 }
 
 Report::~Report() {
+}
+
+QString Report::GetDefaultReportPath() {
+  return QDir(storage_->GetOutputLocation()).filePath(
+        QString("build_") +
+        QDateTime::currentDateTime().toString(Qt::ISODate) +
+        QString("_report.txt") );
 }
 
 bool Report::GenerateSmartReconstructionReport(QString filepath) {

--- a/src/io/report.cpp
+++ b/src/io/report.cpp
@@ -28,7 +28,7 @@ Report::~Report() {
 
 QString Report::GetDefaultReportPath() {
   return QDir(storage_->GetOutputLocation()).filePath(
-        QString("build_") +
+        QString("models/build_") +
         QDateTime::currentDateTime().toString(Qt::ISODate) +
         QString("_report.txt") );
 }

--- a/src/io/report.h
+++ b/src/io/report.h
@@ -23,6 +23,8 @@ class Report {
   explicit Report(Project* project);
   ~Report();
 
+  QString GetDefaultReportPath();
+
   bool GenerateSmartReconstructionReport(QString filepath);
 
  private:

--- a/src/io/storageio.cpp
+++ b/src/io/storageio.cpp
@@ -119,31 +119,17 @@ bool StorageIO::ReadCalibrationFileRow(
 
 void StorageIO::WriteReconstructions(
     const std::vector<theia::Reconstruction*>& reconstructions) {
-  QString models_path = QDir(storage_->output_location_)
-      .filePath(QString("models"));
-
-  if (!QDir(models_path).exists()) {
-    QDir().mkdir(models_path);
-  }
-
-  std::string model_file_template = (QDir(models_path).filePath(
+  std::string model_file_template = QDir(storage_->output_location_).filePath(
+      QString("models/build_") +
       QDateTime::currentDateTime().toString(Qt::ISODate) +
-      QString("_%d.model"))).toStdString();
+      QString("_%d.model")).toStdString();
 
   for (int i = 0; i < reconstructions.size(); i++) {
     std::string output_file = theia::StringPrintf(
         model_file_template.c_str(), i);
-    QString file_name = QString::fromUtf8(output_file.c_str());
-    QFile file(file_name);
-
-    if (file.open(QIODevice::WriteOnly)) {
-      LOG(INFO) << "Writing a model to " << output_file;
-      CHECK(theia::WriteReconstruction(*reconstructions[i], output_file))
-      << "Failed to write model to filesystem.";
-      file.close();
-    } else {
-      LOG(INFO) << "Failed to open " << output_file;
-    }
+    LOG(INFO) << "Writing a model to " << output_file;
+    CHECK(theia::WriteReconstruction(*reconstructions[i], output_file))
+    << "Failed to write model to filesystem.";
   }
 
   LOG(INFO) << "Reconstructions have been saved to filesystem.";

--- a/src/io/storageio.cpp
+++ b/src/io/storageio.cpp
@@ -2,6 +2,10 @@
 
 #include "storageio.h"
 
+#include <string>
+
+#include <QDateTime>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 
@@ -111,4 +115,22 @@ bool StorageIO::ReadCalibrationFileRow(
   (*stream) >> temp_camera_intrinsics_prior->radial_distortion.value[1];
 
   return true;
+}
+
+bool StorageIO::WriteReconstructions(
+    const std::vector<theia::Reconstruction*>& reconstructions) {
+  std::string model_file_template = QDir(storage_->output_location_).filePath(
+    QString("models/build_") +
+    QDateTime::currentDateTime().toString(Qt::ISODate) +
+    QString("_%d.model") ).toStdString();
+
+  for (int i = 0; i < reconstructions.size(); i++) {
+    std::string output_file =
+        theia::StringPrintf(model_file_template.c_str(), i);
+    LOG(INFO) << "Writing a model to " << output_file;
+    CHECK(theia::WriteReconstruction(*reconstructions[i], output_file))
+    << "Failed to write model to filesystem.";
+  }
+
+  LOG(INFO) << "Reconstructions have been saved to filesystem.";
 }

--- a/src/io/storageio.h
+++ b/src/io/storageio.h
@@ -27,6 +27,8 @@
 #ifndef SRC_IO_STORAGEIO_H_
 #define SRC_IO_STORAGEIO_H_
 
+#include <vector>
+
 #include <QMap>
 #include <QString>
 #include <QTextStream>
@@ -43,6 +45,9 @@ class StorageIO {
   bool ReadCalibrationFile(
       QString calibration_file_path,
       QMap<QString, theia::CameraIntrinsicsPrior>* camera_intrinsics_prior);
+
+  bool WriteReconstructions(
+      const std::vector<theia::Reconstruction*>& reconstructions);
 
   ~StorageIO();
 

--- a/src/io/storageio.h
+++ b/src/io/storageio.h
@@ -46,7 +46,7 @@ class StorageIO {
       QString calibration_file_path,
       QMap<QString, theia::CameraIntrinsicsPrior>* camera_intrinsics_prior);
 
-  bool WriteReconstructions(
+  void WriteReconstructions(
       const std::vector<theia::Reconstruction*>& reconstructions);
 
   ~StorageIO();

--- a/src/options.h
+++ b/src/options.h
@@ -29,14 +29,13 @@
 
 #include <theia/theia.h>
 
-// TODO(uladbohdan): to be consistent in using "using" keyword.
-using theia::MatchingStrategy;
 using theia::DescriptorExtractorType;
-using theia::ReconstructionBuilderOptions;
-using theia::FeatureMatcherOptions;
-using theia::ReconstructionEstimatorOptions;
 using theia::FeatureExtractor;
+using theia::FeatureMatcherOptions;
+using theia::MatchingStrategy;
 using theia::OptimizeIntrinsicsType;
+using theia::ReconstructionBuilderOptions;
+using theia::ReconstructionEstimatorOptions;
 
 class Options {
   friend class OptionsDialog;
@@ -60,7 +59,7 @@ class Options {
 
   FeatureMatcherOptions GetFeatureMatcherOptions();
 
-  theia::ReconstructionEstimatorOptions GetReconstructionEstimatorOptions();
+  ReconstructionEstimatorOptions GetReconstructionEstimatorOptions();
 
   ~Options();
 
@@ -87,12 +86,6 @@ class Options {
   OptimizeIntrinsicsType intrinsics_to_optimize_ =
       OptimizeIntrinsicsType::FOCAL_LENGTH |
       OptimizeIntrinsicsType::RADIAL_DISTORTION;
-};
-
-enum ReconstructionStatus {
-  NOT_BUILT = 0,              // There is no any models.
-  BUILT = 1,                  // Models built and saved into filesystem.
-  LOADED_INTO_MEMORY = 2      // Models read from disk and stored into Storage.
 };
 
 #endif  // SRC_OPTIONS_H_

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -13,9 +13,6 @@ Project::Project(QString project_path) :
   features_ = new Features(storage_, options_);
 
   storage_->SetOptions(options_);
-
-  // Searching for models.
-  storage_->LoadModelsList();
 }
 
 Project::Project(QString project_name,
@@ -40,7 +37,7 @@ Project::Project(QString project_name,
 
   // Creating out/ directory.
   QDir(project_path).mkdir("out");
-  QDir(project_path + "out").mkdir("models");
+  QDir(QDir(project_path).filePath("out")).mkdir("models");
   storage_->SetOutputLocation(GetDefaultOutputPath());
   options_ = new Options(storage_->GetOutputLocation());
   features_ = new Features(storage_, options_);

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -13,6 +13,9 @@ Project::Project(QString project_path) :
   features_ = new Features(storage_, options_);
 
   storage_->SetOptions(options_);
+
+  // Searching for models.
+  storage_->LoadModelsList();
 }
 
 Project::Project(QString project_name,

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -40,6 +40,7 @@ Project::Project(QString project_name,
 
   // Creating out/ directory.
   QDir(project_path).mkdir("out");
+  QDir(project_path + "out").mkdir("models");
   storage_->SetOutputLocation(GetDefaultOutputPath());
   options_ = new Options(storage_->GetOutputLocation());
   features_ = new Features(storage_, options_);

--- a/src/reconstructor.cpp
+++ b/src/reconstructor.cpp
@@ -8,6 +8,8 @@
 #include <QMap>
 #include <QString>
 
+#include "io/storageio.h"
+
 Reconstructor::Reconstructor(Project* project) : project_(project) {
   storage_ = project_->GetStorage();
   options_ = project_->GetOptions();
@@ -58,8 +60,7 @@ void Reconstructor::SmartBuild() {
   report_->colorizing_time_ = colorizing_timer.ElapsedTimeInSeconds();
   LOG(INFO) << "Reconstruction colorized successfully!";
 
-  storage_->SetReconstructions(reconstructions);
-  storage_->WriteReconstructions();
+  StorageIO(storage_).WriteReconstructions(reconstructions);
 
   report_->overall_time_ = overall_timer.ElapsedTimeInSeconds();
 

--- a/src/reconstructor.cpp
+++ b/src/reconstructor.cpp
@@ -64,8 +64,7 @@ void Reconstructor::SmartBuild() {
   report_->overall_time_ = overall_timer.ElapsedTimeInSeconds();
 
   // Generating a report.
-  QString report_path =
-      QDir(storage_->GetOutputLocation()).filePath("reconstruction_report.txt");
+  QString report_path = report_->GetDefaultReportPath();
   bool ok = report_->GenerateSmartReconstructionReport(report_path);
   if (ok) {
     LOG(INFO) << "Report was successfully created. Written to "

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -123,11 +123,12 @@ void Storage::ReadReconstructions() {
 
   LOG(INFO) << "Reading models...";
   QRegExp rx(MODEL_FILENAME_PATTERN);
+  rx.setPatternSyntax(QRegExp::Wildcard);
   while (it.hasNext()) {
     QString next_model;
     next_model = it.next();
 
-    if (rx.indexIn(next_model) == -1) {
+    if (rx.exactMatch(next_model) == false) {
       LOG(WARNING) << "\t" << next_model.toStdString() <<
                    "- \"does not match the regex.\"";
       continue;

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -2,6 +2,8 @@
 
 #include "storage.h"
 
+#include <QDateTime>
+
 Storage::Storage() : options_(nullptr),
                      images_(nullptr),
                      images_path_(""),
@@ -147,14 +149,27 @@ void Storage::ReadReconstructions() {
 
 void Storage::WriteReconstructions() {
   std::string output_file_template =
-      QDir(output_location_).filePath("model").toStdString();
+      QDir(output_location_).filePath("model-%d.binary").toStdString();
 
   for (int i = 0; i < reconstructions_.size(); i++) {
     std::string output_file =
-        theia::StringPrintf("%s-%d.binary", output_file_template.c_str(), i);
+        theia::StringPrintf(output_file_template.c_str(), i);
     LOG(INFO) << "Writing reconstruction " << i << " to " << output_file;
     CHECK(theia::WriteReconstruction(*reconstructions_[i], output_file))
     << "Could not write reconstruction to file";
+  }
+
+  std::string alternative_file_template = QDir(output_location_).filePath(
+    QString("build_") +
+    QDateTime::currentDateTime().toString(Qt::ISODate) +
+    QString("_%d.model") ).toStdString();
+
+  for (int i = 0; i < reconstructions_.size(); i++) {
+    std::string output_file =
+        theia::StringPrintf(alternative_file_template.c_str(), i);
+    LOG(INFO) << "Writing a copy to " << output_file;
+    CHECK(theia::WriteReconstruction(*reconstructions_[i], output_file))
+    << "Failed to write alternative reconstruction to filesystem.";
   }
 
   LOG(INFO) << "Reconstructions has been saved to filesystem.";

--- a/src/storage.h
+++ b/src/storage.h
@@ -10,6 +10,7 @@
 #include <QtAlgorithms>
 #include <QDirIterator>
 #include <QFileInfo>
+#include <QStringList>
 #include <QTextStream>
 #include <QVector>
 
@@ -25,6 +26,7 @@ using theia::Reconstruction;
 
 // The pattern may be extended with image extensions which are supported
 // by Theia.
+// TODO(uladbohdan): to achieve consistency in regexps.
 const QString IMAGE_FILENAME_PATTERN = "\\b.(jpg|JPG|jpeg|JPEG|png|PNG)";
 const QString MODEL_FILENAME_PATTERN = "*.model";
 
@@ -73,12 +75,19 @@ class Storage {
 
   ReconstructionStatus GetReconstructionStatus() const;
 
+  QStringList GetReconstrutionNames();
+
   bool GetCalibration(QMap<QString, theia::CameraIntrinsicsPrior>*);
+
+  void LoadModelsList();
 
   ~Storage();
 
  private:
+  // Two following data structures must be synced.
   std::vector<Reconstruction*> reconstructions_;
+  QStringList reconstruction_names_;
+
   QVector<QString>* images_;
   QString images_path_;
   QString output_location_;

--- a/src/storage.h
+++ b/src/storage.h
@@ -62,20 +62,9 @@ class Storage {
 
   void SetOutputLocation(const QString& output_location);
 
-  // Check if model already in memory, load it if not, and return.
-  Reconstruction* GetReconstruction(const int number);
+  Reconstruction* GetReconstruction(const QString reconstruction_name);
 
-  // Update model in memory and sets status_ to LOADED_IN_MEMORY.
-  void SetReconstructions(const std::vector<Reconstruction*>& reconstructions);
-
-  // Write all models to binary file.
-  void WriteReconstructions();
-
-  void SetReconstructionStatus(ReconstructionStatus status);
-
-  ReconstructionStatus GetReconstructionStatus() const;
-
-  QStringList GetReconstrutionNames();
+  QStringList& GetReconstructions();
 
   bool GetCalibration(QMap<QString, theia::CameraIntrinsicsPrior>*);
 
@@ -84,19 +73,25 @@ class Storage {
   ~Storage();
 
  private:
-  // Two following data structures must be synced.
-  std::vector<Reconstruction*> reconstructions_;
-  QStringList reconstruction_names_;
+  // List of full paths to reconstructions (.model files) in filesystem.
+  QStringList reconstructions_;
+  // The only reason to have this field is to be able to deallocate memory
+  // allocated for the reconstruction.
+  Reconstruction* loaded_reconstruction_;
+  QString loaded_reconstruction_name_;
 
   QVector<QString>* images_;
   QString images_path_;
   QString output_location_;
-  ReconstructionStatus status_;
 
   Options* options_;
 
-  // Reads model from binary file.
-  void ReadReconstructions();
+  // Reads one specific Reconstruction by name from filesystem.
+  // As only one Reconstruction may be rendered at the same time, no need to
+  // have them all loaded to memory.
+  // As this method is private, you must call GetReconstruction() method, which
+  // also checks if reconstruction is already in memory.
+  void LoadReconstruction(QString reconstruction_name);
 
   QString GetCameraIntrinsicsPath() const;
 };

--- a/src/storage.h
+++ b/src/storage.h
@@ -26,7 +26,7 @@ using theia::Reconstruction;
 // The pattern may be extended with image extensions which are supported
 // by Theia.
 const QString IMAGE_FILENAME_PATTERN = "\\b.(jpg|JPG|jpeg|JPEG|png|PNG)";
-const QString MODEL_FILENAME_PATTERN = "model-\\d+.binary";
+const QString MODEL_FILENAME_PATTERN = "*.model";
 
 const QString DEFAULT_CALIBRATION_FILE_NAME = "camera_intrinsics.txt";
 

--- a/ui/reconstruction_window.cpp
+++ b/ui/reconstruction_window.cpp
@@ -2,6 +2,8 @@
 
 #include "reconstruction_window.h"
 
+#include <QInputDialog>
+
 ReconstructionWindow::ReconstructionWindow() {
   QGLViewer();
 }
@@ -17,8 +19,25 @@ void ReconstructionWindow::UpdateActiveProject(Project* project) {
 
 void ReconstructionWindow::BuildFromDefaultPath() {
   world_points_.clear();
+
+  QStringList items = project_->GetStorage()->GetReconstrutionNames();
+  for (auto& item : items) {
+    item = FileNameFromPath(item);
+  }
+
+  bool ok;
+  QString reconstruction_name =
+      QInputDialog::getItem(this, "Reconstruction picker",
+                            "Choose a reconstruction to render",
+                            items, 0, false, &ok);
+  if (!ok || (reconstruction_name == "")) {
+    LOG(WARNING) << "Failed to choose a model to render.";
+    return;
+  }
+
   theia::Reconstruction* reconstruction =
-      project_->GetStorage()->GetReconstruction(0);
+      project_->GetStorage()->GetReconstruction(
+        items.indexOf(QRegExp(reconstruction_name)));
   if (!reconstruction) {
     LOG(WARNING) << "There is no built models!";
     return;


### PR DESCRIPTION
* Storing all reports and builds (no overwriting)
* Getting rid of ReconstructionStatus enum (no more need)
* Memory improvements: loading model to memory only if we need it. Storing maximum one reconstruction at once
* Interface of Storage class simplified
* WriteReconstructions moved to StorageIO
* All models now have to be in out/models/ directory and have .model extension (these two conditions are enough for models to be recognized by Appa)
* Model picker before rendering (no default models, you may choose)